### PR TITLE
Fix certificate on OS X

### DIFF
--- a/System/Certificate/X509/MacOS.hs
+++ b/System/Certificate/X509/MacOS.hs
@@ -11,10 +11,13 @@ import Control.Applicative
 import Data.Either
 import Data.Maybe
 
+keyChain :: String
+keyChain = "/System/Library/Keychains/SystemRootCertificates.keychain"
+
 findCertificate :: (X509 -> Bool) -> IO (Maybe X509)
 findCertificate f = do
-  (_, h, _, ph) <- runInteractiveCommand "security find-certificate -pa"
-  waitForProcess ph
-  pems <- parsePEMs <$> hGetContents h
+  (_, Just hout, _, ph) <- createProcess (proc "security" ["find-certificate", "-pa", keyChain]) { std_out = CreatePipe }
+  pems <- parsePEMs <$> hGetContents hout
+  _ <- waitForProcess ph
   let targets = rights $ map (decodeCertificate . LBS.fromChunks .  pure . snd) $ filter ((=="CERTIFICATE") . fst) pems
   return $ listToMaybe $ filter f targets


### PR DESCRIPTION
This seems to fix finding the certificate. Tested on OS X 10.7.3 with GHC 7.4.1. Tested some https requests with http-conduit, with a modified tls-extra (removed the -DNOCERTVERIFY from OS X)

Test suite does not run yet, since it depends on the file `/etc/ssl/certs` which OS  X does not have.
