### PR TITLE
Fix build for GHC 7.6

### DIFF
--- a/System/Certificate/X509/Unix.hs
+++ b/System/Certificate/X509/Unix.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Module      : System.Certificate.X509
 -- License     : BSD-style
@@ -30,9 +31,10 @@ import qualified Data.ByteString.Lazy as L
 
 import Control.Applicative ((<$>))
 import Control.Exception
-import Control.Monad
 
+#if !MIN_VERSION_base(4,6,0)
 import Prelude hiding (catch)
+#endif
 
 defaultSystemPath :: FilePath
 defaultSystemPath = "/etc/ssl/certs/"


### PR DESCRIPTION
This fixes a couple build issues in System.Certificate.X509.Unix , so certificate can be built under GHC 7.6.

In base 4.6, Prelude no longer exports catch.

Also, remove redundant import Control.Monad.  Apparently, prior versions of GHC
(7.4 and earlier) missed this.  This change does not break the build on
GHC 7.0.3 or 7.4.2 .
