### PR TITLE
Fix Haddock formatting in header for KeyRSA.hs

### DIFF
--- a/Data/Certificate/KeyRSA.hs
+++ b/Data/Certificate/KeyRSA.hs
@@ -5,7 +5,7 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
--- Read/Write Private/Public RSA Key
+-- Read\/Write Private\/Public RSA Key
 --
 
 module Data.Certificate.KeyRSA


### PR DESCRIPTION
Small fix to the haddock formatting (usual formatting error).
