### PR TITLE
order of DSA key components doesn't match openssl

### DIFF
--- a/Data/Certificate/KeyDSA.hs
+++ b/Data/Certificate/KeyDSA.hs
@@ -22,7 +22,7 @@ import qualified Crypto.Types.PubKey.DSA as DSA
 parsePrivate :: [ASN1] -> Either String (DSA.PublicKey, DSA.PrivateKey)
 parsePrivate
         [ Start Sequence
-        , IntVal 0, IntVal pub, IntVal priv, IntVal p, IntVal g, IntVal q
+        , IntVal 0, IntVal p, IntVal q, IntVal g, IntVal pub, IntVal priv
         , End Sequence ] = Right (pubkey, privkey)
     where
         privkey = DSA.PrivateKey { DSA.private_params = params, DSA.private_x = priv }
@@ -42,11 +42,11 @@ encodePrivate (pubkey, privkey) = encodeASN1 DER pkseq
         where pkseq =
                 [ Start Sequence
                 , IntVal 0
+                , IntVal p
+                , IntVal q
+                , IntVal g
                 , IntVal $ DSA.public_y pubkey
                 , IntVal $ DSA.private_x privkey
-                , IntVal p
-                , IntVal g
-                , IntVal q
                 , End Sequence
                 ]
               (p,g,q) = DSA.private_params privkey


### PR DESCRIPTION
The order of key components / parameters of the ASN1 encoding of DSA public/private key pair does not match the one openssl generates. 

According to http://www.openssl.org/docs/apps/dsa.html openssl encodes it as

Constant 0, p, q, g, public key, private key

Please disregard this pull request if it's not applicable (e.q. you are following a different, incompatible standard)
