### PR TITLE
getSystemCertificateStore throws an exception when crt files cannot be read

### DIFF
--- a/System/Certificate/X509/Unix.hs
+++ b/System/Certificate/X509/Unix.hs
@@ -59,5 +59,8 @@ getSystemPath = E.catch (getEnv envPathOverride) inDefault
         inDefault _ = return defaultSystemPath
 
 readCertificates :: FilePath -> IO [X509]
-readCertificates file = either (const []) (rights . map getCert) . pemParseBS <$> B.readFile file
-    where getCert pem = decodeCertificate $ L.fromChunks [pemContent pem]
+readCertificates file = E.catch (either (const []) (rights . map getCert) . pemParseBS <$> B.readFile file) skipIOError
+    where
+        getCert pem = decodeCertificate $ L.fromChunks [pemContent pem]
+        skipIOError :: E.IOException -> IO [X509]
+        skipIOError _ = return []


### PR DESCRIPTION
# The problem

```
[ghci] Prelude System.Certificate.X509> getSystemCertificateStore
[ghci] *** Exception: /etc/ssl/certs/localhost.crt: openBinaryFile: permission denied (Permission denied)
```
# Why

```
% ls -l /etc/ssl/certs/
-rw-r--r--. 1 root root 571450 Apr  8  2010 ca-bundle.crt
-rw-r--r--. 1 root root 651083 Apr  8  2010 ca-bundle.trust.crt
-rw-------  1 root root   1192 Aug 24 19:01 localhost.crt
```

So our administrator doesn't want the file to be read by everyone.
# Solution

Check whether crt files are readable:

```
 listDirectoryCerts path = (map (path </>) . filter isCert <$> getDirectoryContents path)
                       >>= filterM doesFileExist
+                      >>= filterM (liftM readable . getPermissions)
```
