### PR TITLE
be more lenient when parsing alternate names

### DIFF
--- a/x509/Data/X509/Ext.hs
+++ b/x509/Data/X509/Ext.hs
@@ -30,6 +30,7 @@ module Data.X509.Ext
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
+import Data.ASN1.Stream
 import Data.ASN1.Types
 import Data.ASN1.Parse
 import Data.ASN1.BitArray
@@ -38,6 +39,7 @@ import Data.X509.ExtensionRaw
 import Data.X509.DistinguishedName
 import Control.Applicative
 import Control.Monad.Error
+
 
 -- | key usage flag that is found in the key usage extension field.
 data ExtKeyUsageFlag =
@@ -238,14 +240,17 @@ instance Extension ExtCrlDistributionPoints where
 parseGeneralNames :: ParseASN1 [AltName]
 parseGeneralNames = do
     c <- getNextContainer Sequence
-    r <- sequence $ map toStringy c
-    return r
+    return $ walkList c
   where
-        toStringy (Other Context 1 b) = return $ AltNameRFC822 $ BC.unpack b
-        toStringy (Other Context 2 b) = return $ AltNameDNS $ BC.unpack b
-        toStringy (Other Context 6 b) = return $ AltNameURI $ BC.unpack b
-        toStringy (Other Context 7 b) = return $ AltNameIP  b
-        toStringy b                   = throwError ("GeneralNames: not coping with anything else " ++ show b)
+    walkList [] = []
+    walkList ((Other Context 1 b):ls) = (AltNameRFC822 $ BC.unpack b)
+                                         : walkList ls
+    walkList ((Other Context 2 b):ls) = (AltNameDNS $ BC.unpack b) : walkList ls
+    walkList ((Other Context 6 b):ls) = (AltNameURI $ BC.unpack b) : walkList ls
+    walkList ((Other Context 7 b):ls) = (AltNameIP  b) : walkList ls
+    walkList ((Start _):ls) =
+        let (_, rest) = getConstructedEnd 0 ls in walkList rest
+    walkList (_:ls) = walkList ls
 
 encodeGeneralNames :: [AltName] -> [ASN1]
 encodeGeneralNames names =


### PR DESCRIPTION
The current parser for alternate names bails out when it sees a alternative name format it doesn't understand, even when it can parse others. This prevents tls from validating certificates against a domain that is not the main subject when such unsupported alternate names are present. 
My patch changes the parser to ignore any fields it doesn't understand. This is certainly a crude hack, but it at least allows me to connect to the server. 

As an example, this gist (https://gist.github.com/Philonous/9452127 ) includes a certificate for jabberd.draugr.de, to which you would usually connect via the alternate name draugr.de .
