### PR TITLE
Added FlexibleContexts flag required by ghc-7.9

### DIFF
--- a/x509/Data/X509/CRL.hs
+++ b/x509/Data/X509/CRL.hs
@@ -9,6 +9,8 @@
 --
 -- follows RFC5280 / RFC6818.
 --
+{-# LANGUAGE FlexibleContexts #-}
+
 module Data.X509.CRL
     ( CRL(..)
     , RevokedCertificate(..)

--- a/x509/Data/X509/Cert.hs
+++ b/x509/Data/X509/Cert.hs
@@ -7,6 +7,8 @@
 --
 -- X.509 Certificate types and functions
 --
+{-# LANGUAGE FlexibleContexts #-}
+
 module Data.X509.Cert (Certificate(..)) where
 
 import Data.ASN1.Types

--- a/x509/Data/X509/Ext.hs
+++ b/x509/Data/X509/Ext.hs
@@ -7,6 +7,8 @@
 --
 -- extension processing module.
 --
+{-# LANGUAGE FlexibleContexts #-}
+
 module Data.X509.Ext
     ( Extension(..)
     -- * Common extension usually found in x509v3


### PR DESCRIPTION
Your library didn't not compile under ghc-7.9 without FlexibleContexts flag. I added it.
