### PR TITLE
Add Monoid instances for the certificate chain types.

### DIFF
--- a/x509/Data/X509/CertificateChain.hs
+++ b/x509/Data/X509/CertificateChain.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- |
 -- Module      : Data.X509.CertificateChain
 -- License     : BSD-style
@@ -16,14 +17,15 @@ module Data.X509.CertificateChain
 import Data.X509.Cert (Certificate)
 import Data.X509.Signed (SignedExact, decodeSignedObject, encodeSignedObject)
 import Data.ByteString (ByteString)
+import Data.Monoid (Monoid)
 
 -- | A chain of X.509 certificates in exact form.
 newtype CertificateChain = CertificateChain [SignedExact Certificate]
-    deriving (Show,Eq)
+    deriving (Show,Eq,Monoid)
 
 -- | Represent a chain of X.509 certificates in bytestring form.
 newtype CertificateChainRaw = CertificateChainRaw [ByteString]
-    deriving (Show,Eq)
+    deriving (Show,Eq,Monoid)
 
 -- | Decode a CertificateChainRaw into a CertificateChain if every
 -- raw certificate are decoded correctly, otherwise return the index of the


### PR DESCRIPTION
Vincent, I added Monoid instances for `CertificateChain` and `CertificateChainRaw`. I originally was thinking of using this for handing chain certificates in TLS, but now I see that the chain from each file needs its own key. In any case, the `Monoid` instances still make sense and are natural. They at least allow you to use things like `Foldable.foldMap` when reading a certificate file.

So, in the end I don't really need this. But I already did the PR, so I'm sending it to you and leaving it up to you whether you want to merge it.

Regards,
Yitz