### PR TITLE
Add OS X System keychain to system certificate store

### DIFF
--- a/x509-system/System/X509/MacOS.hs
+++ b/x509-system/System/X509/MacOS.hs
@@ -11,16 +11,19 @@ import Data.Either
 import Data.X509
 import Data.X509.CertificateStore
 
-rootCAKeyChain :: String
+rootCAKeyChain :: FilePath
 rootCAKeyChain = "/System/Library/Keychains/SystemRootCertificates.keychain"
 
-listInKeyChain :: String -> IO [SignedCertificate]
-listInKeyChain keyChain = do
-    (_, Just hout, _, ph) <- createProcess (proc "security" ["find-certificate", "-pa", keyChain]) { std_out = CreatePipe }
+systemKeyChain :: FilePath
+systemKeyChain = "/Library/Keychains/System.keychain"
+
+listInKeyChains :: [FilePath] -> IO [SignedCertificate]
+listInKeyChains keyChains = do
+    (_, Just hout, _, ph) <- createProcess (proc "security" ("find-certificate" : "-pa" : keyChains)) { std_out = CreatePipe }
     pems <- either error id . pemParseLBS <$> LBS.hGetContents hout
     let targets = rights $ map (decodeSignedCertificate . pemContent) $ filter ((=="CERTIFICATE") . pemName) pems
     _ <- targets `seq` waitForProcess ph
     return targets
 
 getSystemCertificateStore :: IO CertificateStore
-getSystemCertificateStore = makeCertificateStore <$> listInKeyChain rootCAKeyChain
+getSystemCertificateStore = makeCertificateStore <$> listInKeyChains [rootCAKeyChain, systemKeyChain]


### PR DESCRIPTION
Intended to fix #49. I have verified this on OS X 10.9.5 and 10.10.3.