### PR TITLE
add OIDs for SHA-512 and SHA-224 with RSA

### DIFF
--- a/x509/Data/X509/AlgorithmIdentifier.hs
+++ b/x509/Data/X509/AlgorithmIdentifier.hs
@@ -55,6 +55,8 @@ sig_table =
         , ([1,2,840,113549,1,1,2], SignatureALG HashMD2 PubKeyALG_RSA)
         , ([1,2,840,113549,1,1,11], SignatureALG HashSHA256 PubKeyALG_RSA)
         , ([1,2,840,113549,1,1,12], SignatureALG HashSHA384 PubKeyALG_RSA)
+        , ([1,2,840,113549,1,1,13], SignatureALG HashSHA512 PubKeyALG_RSA)
+        , ([1,2,840,113549,1,1,14], SignatureALG HashSHA224 PubKeyALG_RSA)
         , ([1,2,840,10040,4,3],    SignatureALG HashSHA1 PubKeyALG_DSA)
         , ([1,2,840,10045,4,3,1],  SignatureALG HashSHA224 PubKeyALG_ECDSA)
         , ([1,2,840,10045,4,3,2],  SignatureALG HashSHA256 PubKeyALG_ECDSA)

--- a/x509/Tests/Tests.hs
+++ b/x509/Tests/Tests.hs
@@ -56,6 +56,8 @@ instance Arbitrary SignatureALG where
         , SignatureALG HashMD2 PubKeyALG_RSA
         , SignatureALG HashSHA256 PubKeyALG_RSA
         , SignatureALG HashSHA384 PubKeyALG_RSA
+        , SignatureALG HashSHA512 PubKeyALG_RSA
+        , SignatureALG HashSHA224 PubKeyALG_RSA
         , SignatureALG HashSHA1 PubKeyALG_DSA
         , SignatureALG HashSHA224 PubKeyALG_ECDSA
         , SignatureALG HashSHA256 PubKeyALG_ECDSA


### PR DESCRIPTION
In particular, SHA-512 is necessary for [this test](https://www.tls-o-matic.com/https/test13/).