### PR TITLE
Public suffix list

### DIFF
--- a/x509-validation/Data/X509/Validation.hs
+++ b/x509-validation/Data/X509/Validation.hs
@@ -27,6 +27,8 @@ module Data.X509.Validation
     , getFingerprint
     -- * Cache
     , module Data.X509.Validation.Cache
+    -- * Internal
+    , validateCertificateName
     ) where
 
 import Control.Applicative

--- a/x509-validation/Tests/Tests.hs
+++ b/x509-validation/Tests/Tests.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Data.ByteString as B
+
+import Data.ASN1.Types
+import Data.X509
+import Data.X509.Validation
+
+
+cert :: B.ByteString -> Certificate
+cert subject = Certificate 1 1
+    (SignatureALG HashSHA512 PubKeyALG_ECDSA)
+    dn
+    undefined
+    dn
+    (PubKeyUnknown [0] "")
+    (Extensions Nothing)
+
+  where
+    dn = DistinguishedName [((getObjectID DnCommonName), ASN1CharacterString UTF8 subject)]
+
+
+main = defaultMain $ testGroup "X509"
+    [ testGroup "validateCertificateName"
+        [ testCase "should accept certificate with an exact matching domain" $
+            validateCertificateName "example.com" (cert "example.com") @?= []
+
+        , testCase "should reject a certificate for a public suffix (TLD)" $
+            validateCertificateName "com" (cert "com") @?= [NameMismatch "com"]
+
+        , testCase "should reject a certificate for a public suffix (SLD)" $
+            validateCertificateName "co.uk" (cert "co.uk") @?= [NameMismatch "co.uk"]
+
+        , testCase "should reject a wildcard certificate for a public suffix (TLD)" $
+            validateCertificateName "example.com" (cert "*.com") @?= [NameMismatch "example.com"]
+
+        , testCase "should reject a wildcard certificate for a public suffix (SLD)" $
+            validateCertificateName "example.co.uk" (cert "*.co.uk") @?= [NameMismatch "example.co.uk"]
+
+        , testCase "should accept wildcard certificate with an exact matching domain" $
+            validateCertificateName "test.git.io" (cert "*.git.io") @?= []
+
+        , testCase "should reject wildcard certificate with an mismatching subdomain (RFC6125 section 6.4.3 rule 2)" $
+            validateCertificateName "sub.test.example.com" (cert "*.example.com") @?= [NameMismatch "sub.test.example.com"]
+        ]
+    ]

--- a/x509-validation/x509-validation.cabal
+++ b/x509-validation/x509-validation.cabal
@@ -33,6 +33,8 @@ Library
                    , crypto-pubkey >= 0.1.4 && < 0.3
                    , crypto-pubkey-types >= 0.4 && < 0.5
                    , cryptohash >= 0.9 && < 0.12
+                   , publicsuffix >= 0 && < 1
+                   , text >= 1 && < 1.3
   Exposed-modules:   Data.X509.Validation
   Other-modules:     Data.X509.Validation.Signature
                      Data.X509.Validation.Fingerprint

--- a/x509-validation/x509-validation.cabal
+++ b/x509-validation/x509-validation.cabal
@@ -11,7 +11,7 @@ Build-Type:          Simple
 Category:            Data
 stability:           experimental
 Homepage:            http://github.com/vincenthz/hs-certificate
-Cabal-Version:       >=1.6
+Cabal-Version:       >=1.8
 
 Library
   Build-Depends:     base >= 3 && < 5
@@ -39,6 +39,22 @@ Library
                      Data.X509.Validation.Cache
                      Data.X509.Validation.Types
   ghc-options:       -Wall
+
+Test-Suite test-x509-validation
+  type:              exitcode-stdio-1.0
+  hs-source-dirs:    Tests
+  Main-is:           Tests.hs
+  Build-Depends:     base >= 3 && < 5
+                   , bytestring
+                   , mtl
+                   , tasty
+                   , tasty-hunit
+                   , hourglass
+                   , asn1-types
+                   , x509
+                   , x509-validation
+                   , crypto-pubkey-types
+  ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures
 
 source-repository head
   type:     git


### PR DESCRIPTION
The first commit adds a few tests for matching the name in the certificate with the domain name the client is trying to connect to. The second commit adds a dependency on `publicsuffix` so matching of wildcard certificates can be done properly. Fixes #38 and vincenthz/hs-tls#105.

The package `publicsuffix` doesn't compile with GHC older than 7.6, but you have travis set up to test all the way back to GHC 7.0. Not sure how important it is to you to keep the package compatible with such old GHC versions...