### PR TITLE
Add explicit timezone to times in CRLs

### DIFF
--- a/x509/Data/X509/CRL.hs
+++ b/x509/Data/X509/CRL.hs
@@ -18,7 +18,7 @@ module Data.X509.CRL
 
 import Control.Applicative
 
-import Data.Hourglass (DateTime)
+import Data.Hourglass (DateTime, TimezoneOffset(..))
 import Data.ASN1.Types
 
 import Data.X509.DistinguishedName

--- a/x509/Data/X509/CRL.hs
+++ b/x509/Data/X509/CRL.hs
@@ -54,7 +54,7 @@ instance ASN1Object RevokedCertificate where
         Right (RevokedCertificate serial t (Extensions Nothing), xs)
     fromASN1 l = Left ("fromASN1: X509.RevokedCertificate: unknown format:" ++ show l)
     toASN1 (RevokedCertificate serial time _) = \xs ->
-        Start Sequence : IntVal serial : ASN1Time TimeGeneralized time Nothing : End Sequence : xs
+        Start Sequence : IntVal serial : ASN1Time TimeGeneralized time (Just (TimezoneOffset 0)) : End Sequence : xs
 
 parseCRL :: ParseASN1 CRL
 parseCRL = do
@@ -83,8 +83,8 @@ encodeCRL crl xs =
     [IntVal $ crlVersion crl] ++
     toASN1 (crlSignatureAlg crl) [] ++
     toASN1 (crlIssuer crl) [] ++
-    [ASN1Time TimeGeneralized (crlThisUpdate crl) Nothing] ++
-    (maybe [] (\t -> [ASN1Time TimeGeneralized t Nothing]) (crlNextUpdate crl)) ++
+    [ASN1Time TimeGeneralized (crlThisUpdate crl) (Just (TimezoneOffset 0))] ++
+    (maybe [] (\t -> [ASN1Time TimeGeneralized t (Just (TimezoneOffset 0))]) (crlNextUpdate crl)) ++
     [Start Sequence] ++
     revoked ++
     [End Sequence] ++

--- a/x509/Data/X509/Cert.hs
+++ b/x509/Data/X509/Cert.hs
@@ -12,7 +12,6 @@
 module Data.X509.Cert (Certificate(..)) where
 
 import Data.ASN1.Types
-import Data.Hourglass (DateTime, TimezoneOffset(TimezoneOffset))
 import Control.Applicative ((<$>), (<*>))
 import Data.X509.Internal
 import Data.X509.PublicKey


### PR DESCRIPTION
OpenSSL does not accept times without an explicit timezone. I believe the offending code is:

https://github.com/openssl/openssl/blob/7f3f41d816bb80e362a5978420f59030b3132c81/crypto/x509/x509_vfy.c#L1878

When using a CRL with times without explicit timezones, when verifying a certificate the library returns messages such as:

    depth=0 C = GB, ST = England, L = West Yorkshire, ..., UID = 2b7cc0de-060b-4498-84f3-d5232415904f
    verify error:num=15:format error in CRL's lastUpdate field
    verify return:1
    depth=0 C = GB, ST = England, L = West Yorkshire, ..., UID = 2b7cc0de-060b-4498-84f3-d5232415904f
    verify error:num=16:format error in CRL's nextUpdate field
    verify return:1
    depth=1 C = GB, ST = England, L = West Yorkshire, ...
    verify error:num=15:format error in CRL's lastUpdate field
    verify return:1
    depth=1 C = GB, ST = England, L = West Yorkshire, ...
    verify error:num=16:format error in CRL's nextUpdate field
    verify return:1
