### PR TITLE
Remove ref to CRLs in validation library summary

### DIFF
--- a/x509-validation/x509-validation.cabal
+++ b/x509-validation/x509-validation.cabal
@@ -1,12 +1,12 @@
 Name:                x509-validation
 Version:             1.6.0
-Description:         X.509 Certificate and CRL validation
+Description:         X.509 validation
 License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
 Maintainer:          Vincent Hanquez <vincent@snarc.org>
-Synopsis:            X.509 Certificate and CRL validation
+Synopsis:            X.509 validation
 Build-Type:          Simple
 Category:            Data
 stability:           experimental


### PR DESCRIPTION
The summary for the `x509-validation` says "X.509 Certificate and CRL validation" but it doesn't seem to do anything with CRLs. It's currently the top hit on Google when searching for "haskell x509 crl" because of this.