### PR TITLE
Order of certificates loaded by readSignedObject

### DIFF
--- a/x509-store/Data/X509/File.hs
+++ b/x509-store/Data/X509/File.hs
@@ -24,11 +24,9 @@ readPEMs filepath = do
 readSignedObject :: (ASN1Object a, Eq a, Show a)
                  => FilePath
                  -> IO [X509.SignedExact a]
-readSignedObject filepath = foldl pemToSigned [] <$> readPEMs filepath
-  where pemToSigned acc pem =
-            case X509.decodeSignedObject $ pemContent pem of
-                Left _    -> acc
-                Right obj -> obj : acc
+readSignedObject filepath = decodePEMs <$> readPEMs filepath
+  where decodePEMs pems =
+          [ obj | pem <- pems, Right obj <- [X509.decodeSignedObject $ pemContent pem] ]
 
 -- | return all the public key that were successfully read from a file.
 readKeyFile :: FilePath -> IO [X509.PrivKey]


### PR DESCRIPTION
Hi,

The function `readSignedObject` reverses the order of the objects read from the file. The order of objects is important (see e.g. http://tools.ietf.org/html/rfc4346#section-7.4.2) and this reversal is deeply surprising.

Typically, certificate chains are stored in a file in order from leaf to root. For instance, [nginx](http://nginx.org/en/docs/http/configuring_https_servers.html#chains) and [Apache](http://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcertificatefile) expect this ordering. Additionally, this is the order that a CertificateChain must be in e.g. the return value to [onCertificateRequest](http://hackage.haskell.org/package/tls-1.2.8/docs/Network-TLS.html#v:onCertificateRequest).

Probably a duplicate of #31 which was closed due to lack of interest, but consider me interested now!

Cheers,

David
