### PR TITLE
Accept any wildcard certificate

### DIFF
--- a/x509-validation/Data/X509/Validation.hs
+++ b/x509-validation/Data/X509/Validation.hs
@@ -57,7 +57,9 @@ data FailedReason =
     | NoCommonName             -- ^ Certificate doesn't have any common name (CN)
     | InvalidName String       -- ^ Invalid name in certificate
     | NameMismatch String      -- ^ connection name and certificate do not match
-    | InvalidWildcard          -- ^ invalid wildcard in certificate
+    | InvalidWildcard          -- ^ invalid wildcard in certificate. This is
+                               --   not used anymore. We keep it around only for
+                               --   backwards compatibility.
     | LeafKeyUsageNotAllowed   -- ^ the requested key usage is not compatible with the leaf certificate's key usage
     | LeafKeyPurposeNotAllowed -- ^ the requested key purpose is not compatible with the leaf certificate's extended key usage
     | LeafNotV3                -- ^ Only authorized an X509.V3 certificate as leaf certificate.
@@ -355,10 +357,6 @@ validateCertificateName fqhn cert
         --
         -- e.g. *.*.server.com will try to litteraly match the '*' subdomain of server.com
         wildcardMatch l
-            -- <star>.com or <star> is always invalid
-            | length l < 2 = [InvalidWildcard]
-            -- some TLD like .uk got small subTLD like (.co.uk), and we don't want to accept *.co.uk
-            | length (head l) <= 2 && length (head $ drop 1 l) <= 3 && length l < 3 = [InvalidWildcard]
             | l == take (length l) (reverse $ splitDot fqhn) = [] -- success: we got a match
             | otherwise                                      = [NameMismatch fqhn]
 


### PR DESCRIPTION
The validator should not make any judgement about the validity of a wildcard
name in the certificate. As long as the the certificate is syntactically
well-formed and the user trusts the trust anchor, the certificate should be
accepted.

The powers that be were consulted on that matter, here are excerpts from the
discussion:

> There are valid wildcard certs out there for *.psl.tld. The CAB Forum
> Baseline Requirements require that the PSL be checked and taken note of
> but - for good reason - do not _prohibit_ issuance to *.psl.tld. There are
> some circumstances, particularly for the PRIVATE part of the list, where
> such a cert is entirely reasonable.

and

> *.amazon is a perfectly valid cert. As is *.appspot.com, even thought
> appspot.com is in the PSL.

(PSL: publicsuffix list)