### PR TITLE
Provide HaLVM support by removing unused dependencies

### DIFF
--- a/x509-store/x509-store.cabal
+++ b/x509-store/x509-store.cabal
@@ -18,9 +18,6 @@ Library
                    , bytestring
                    , mtl
                    , containers
-                   , directory
-                   , filepath
-                   , process
                    , pem >= 0.1 && < 0.3
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10

--- a/x509-validation/Data/X509/Validation/Types.hs
+++ b/x509-validation/Data/X509/Validation/Types.hs
@@ -11,8 +11,9 @@ module Data.X509.Validation.Types
     , HostName
     ) where
 
-import Network.BSD (HostName)
 import Data.ByteString (ByteString)
+
+type HostName = String
 
 -- | identification of the connection consisting of the
 -- fully qualified host name (e.g. www.example.com) and

--- a/x509-validation/x509-validation.cabal
+++ b/x509-validation/x509-validation.cabal
@@ -21,9 +21,6 @@ Library
                    , network
                    , mtl
                    , containers
-                   , directory
-                   , filepath
-                   , process
                    , hourglass
                    , data-default-class
                    , pem >= 0.1 && < 0.3

--- a/x509-validation/x509-validation.cabal
+++ b/x509-validation/x509-validation.cabal
@@ -18,7 +18,6 @@ Library
                    , bytestring
                    , memory
                    , byteable
-                   , network
                    , mtl
                    , containers
                    , hourglass

--- a/x509/x509.cabal
+++ b/x509/x509.cabal
@@ -19,9 +19,6 @@ Library
                    , memory
                    , mtl
                    , containers
-                   , directory
-                   , filepath
-                   , process
                    , hourglass
                    , pem >= 0.1 && < 0.3
                    , asn1-types >= 0.3.0 && < 0.4


### PR DESCRIPTION
Turns out many of the dependencies that cause breakages with the HaLVM are redundant in the first place, so I'm assuming removing them won't be very controversial.

The only dependency actually used is the `network` one, but all it pulls in is the alias of `HostName` to `String`. I'm hoping you'd be OK with just adding this alias directly and removing the `network` dependency. It shouldn't cause any problems.