### PR TITLE
Read file or directory into CertificateStore

### DIFF
--- a/x509-store/Data/X509/CertificateStore.hs
+++ b/x509-store/Data/X509/CertificateStore.hs
@@ -14,6 +14,7 @@ import Data.Monoid
 import Data.PEM (pemParseBS, pemContent)
 import Data.X509
 import qualified Data.Map as M
+import Control.Applicative ((<$>))
 import Control.Monad (mplus, filterM)
 import System.Directory (getDirectoryContents, doesFileExist, doesDirectoryExist)
 import System.FilePath ((</>))

--- a/x509-store/Data/X509/CertificateStore.hs
+++ b/x509-store/Data/X509/CertificateStore.hs
@@ -1,16 +1,25 @@
 module Data.X509.CertificateStore
     ( CertificateStore
     , makeCertificateStore
+    , readCertificateStore
     -- * Queries
     , findCertificate
     , listCertificates
     ) where
 
-import Data.List (foldl')
+import Data.Char (isDigit, isHexDigit)
+import Data.Either (rights)
+import Data.List (foldl', isPrefixOf)
 import Data.Monoid
+import Data.PEM (pemParseBS, pemContent)
 import Data.X509
 import qualified Data.Map as M
-import Control.Monad (mplus)
+import Control.Monad (mplus, filterM)
+import System.Directory (getDirectoryContents, doesFileExist, doesDirectoryExist)
+import System.FilePath ((</>))
+import qualified Control.Exception as E
+import qualified Data.ByteString as B
+
 
 -- | A Collection of certificate or store of certificates.
 data CertificateStore = CertificateStore (M.Map DistinguishedName SignedCertificate)
@@ -38,3 +47,51 @@ findCertificate dn store = lookupIn store
 listCertificates :: CertificateStore -> [SignedCertificate]
 listCertificates (CertificateStore store) = map snd $ M.toList store
 listCertificates (CertificateStores l)    = concatMap listCertificates l
+
+-- | Create certificate store by reading certificates from file or directory
+--
+-- This function can be used to read multiple certificates from either
+-- single file (multiple PEM formatted certificates concanated) or
+-- directory (one certificate per file, file names are hashes from
+-- certificate).
+readCertificateStore :: FilePath -> IO (Maybe CertificateStore)
+readCertificateStore path = do
+    isDir  <- doesDirectoryExist path
+    isFile <- doesFileExist path
+    wrapStore <$> (if isDir then makeDirStore else if isFile then makeFileStore else return [])
+  where
+    wrapStore :: [SignedCertificate] -> Maybe CertificateStore
+    wrapStore [] = Nothing
+    wrapStore l  = Just $ makeCertificateStore l
+
+    makeFileStore = readCertificates path
+    makeDirStore  = do
+        certFiles <- listDirectoryCerts path
+        concat <$> mapM readCertificates certFiles
+
+-- Try to read certificate from the content of a file.
+--
+-- The file may contains multiple certificates
+readCertificates :: FilePath -> IO [SignedCertificate]
+readCertificates file = E.catch (either (const []) (rights . map getCert) . pemParseBS <$> B.readFile file) skipIOError
+    where
+        getCert = decodeSignedCertificate . pemContent
+        skipIOError :: E.IOException -> IO [SignedCertificate]
+        skipIOError _ = return []
+
+-- List all the path susceptible to contains a certificate in a directory
+--
+-- if the parameter is not a directory, hilarity follows.
+listDirectoryCerts :: FilePath -> IO [FilePath]
+listDirectoryCerts path =
+    getDirContents >>= filterM doesFileExist
+  where
+    isHashedFile s = length s == 10
+                  && isDigit (s !! 9)
+                  && (s !! 8) == '.'
+                  && all isHexDigit (take 8 s)
+    isCert x = (not $ isPrefixOf "." x) && (not $ isHashedFile x)
+
+    getDirContents = E.catch (map (path </>) . filter isCert <$> getDirectoryContents path) emptyPaths
+            where emptyPaths :: E.IOException -> IO [FilePath]
+                  emptyPaths _ = return []

--- a/x509-store/x509-store.cabal
+++ b/x509-store/x509-store.cabal
@@ -18,6 +18,8 @@ Library
                    , bytestring
                    , mtl
                    , containers
+                   , directory
+                   , filepath
                    , pem >= 0.1 && < 0.3
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10


### PR DESCRIPTION
This pull request moves functions from `System.X509.Unix` into `Data.X509.CertificateStore` and exports `Data.X509.CertificateStore.readCertificateStore :: FilePath -> IO (Maybe CertificateStore)`. 

`readCertificateStore` reads given path (file or directory) into `CertificateStore`. This makes it easy and convenient to read CA bundle files.

`System.X509.Unix` is also modified to use `Data.X509.CertificateStore.readCertificateStore`.