### PR TITLE
Certificate name validation

### DIFF
--- a/x509-validation/Data/X509/Validation.hs
+++ b/x509-validation/Data/X509/Validation.hs
@@ -350,9 +350,12 @@ validateCertificateName fqhn cert
               | l == splitDot fqhn  -> [] -- success: we got a match
               | otherwise           -> [NameMismatch fqhn]
 
-        -- a wildcard matches a single domain name component
+        -- A wildcard matches a single domain name component.
         --
-        -- only 1 wildcard is valid, and if multiples are present
+        -- e.g. *.server.com will match www.server.com but not www.m.server.com
+        --
+        -- Only 1 wildcard is valid and only for the left-most component. If
+        -- used at other positions or if multiples are present
         -- they won't have a wildcard meaning but will be match as normal star
         -- character to the fqhn and inevitably will fail.
         --


### PR DESCRIPTION
This request changes domain name matching in `x509-validation` to get closer to other implementations and RFCs :

- domain name matching is now case-insensitive

- a wildcard in the certificate domain name matches only a single domain component (see RFC 2818: _Names may contain the wildcard character '*' which is considered to match any single domain name component or component fragment._)

Case conversion is performed directly in `splitDot`, and the function call is now moved into `matchDomain` so that the original name before conversion can be returned inside `InvalidName`.

A wildcard is supported only for the left-most component just like before. I didn’t consider extending this or supporting component fragments like `f*o.example.com` because this is more complex and probably never used in practice (discussed somehow in RFC 6125 §7.2).
