### PR TITLE
Fix ECC PKey name to OID

### DIFF
--- a/x509/Data/X509/AlgorithmIdentifier.hs
+++ b/x509/Data/X509/AlgorithmIdentifier.hs
@@ -82,7 +82,7 @@ saltLen HashSHA256 = 32
 saltLen HashSHA384 = 48
 saltLen HashSHA512 = 64
 saltLen HashSHA224 = 28
-saltLen _          = error "toASN1: X509.SignatureAlg.HashAlg: Unkonwn hash"
+saltLen _          = error "toASN1: X509.SignatureAlg.HashAlg: Unknown hash"
 
 instance ASN1Object SignatureALG where
     fromASN1 (Start Sequence:OID oid:Null:End Sequence:xs) =

--- a/x509/Data/X509/PublicKey.hs
+++ b/x509/Data/X509/PublicKey.hs
@@ -175,9 +175,9 @@ encodePK key = asn1Container Sequence (encodeInner key)
     encodeInner (PubKeyEC (PubKeyEC_Named curveName (SerializedPoint bits))) =
         asn1Container Sequence [pkalg,OID eOid] ++ [BitString $ toBitArray bits 0]
       where
-        eOid = case curveName of
-                    ECC.SEC_p384r1 -> [1,3,132,0,34]
-                    _              -> error ("undefined curve OID: " ++ show curveName)
+        eOid = case lookupOID curvesOIDTable curveName of
+                    Just oid -> oid
+                    _        -> error ("undefined curve OID: " ++ show curveName)
     encodeInner (PubKeyEC (PubKeyEC_Prime {})) =
         error "encodeInner: unimplemented public key EC_Prime"
     encodeInner (PubKeyDH _) = error "encodeInner: unimplemented public key DH"


### PR DESCRIPTION
The `encodePK` function in ``Data/X509/PublicKey.hs`` used to only support `secp384r1`.  It now supports all the curves listed in `curvesOIDTable`.  Also took the opportunity to convert the table to a Bimap and drop some curves that are rather obsolete/insecure from that mapping.  Further pruning may be wise.