### PR TITLE
Fix implicit certificate version.

### DIFF
--- a/x509/Data/X509/Cert.hs
+++ b/x509/Data/X509/Cert.hs
@@ -53,7 +53,7 @@ instance ASN1Object Certificate where
 
 parseCertHeaderVersion :: ParseASN1 Int
 parseCertHeaderVersion =
-    maybe 1 id <$> onNextContainerMaybe (Container Context 0) (getNext >>= getVer)
+    maybe 0 id <$> onNextContainerMaybe (Container Context 0) (getNext >>= getVer)
   where getVer (IntVal v) = return $ fromIntegral v
         getVer _          = throwParseError "unexpected type for version"
 


### PR DESCRIPTION
X.509 certificates without an explicit version are v1 certificates,
but v1 is actually stored as 0 (just as v3 is 2).  The Data.X509 API
report the raw stored certificate versions, not the marketing name.
Therefore, the implicit version is 0, not 1.