### PR TITLE
Fix ByteArrayAccess instance for Fingerprint

### DIFF
--- a/x509-validation/Data/X509/Validation/Fingerprint.hs
+++ b/x509-validation/Data/X509/Validation/Fingerprint.hs
@@ -19,9 +19,7 @@ import Data.ByteString (ByteString)
 
 -- | Fingerprint of a certificate
 newtype Fingerprint = Fingerprint ByteString
-    deriving (Show,Eq)
-
-instance ByteArrayAccess Fingerprint
+    deriving (Show,Eq,ByteArrayAccess)
 
 -- | Get the fingerprint of the whole signed object
 -- using the hashing algorithm specified


### PR DESCRIPTION
The instance was defined but with empty implementation.