### PR TITLE
Use absent parameters in EdDSA signature algorithms

### DIFF
--- a/x509/Data/X509/AlgorithmIdentifier.hs
+++ b/x509/Data/X509/AlgorithmIdentifier.hs
@@ -113,4 +113,5 @@ instance ASN1Object SignatureALG where
         Left "fromASN1: X509.SignatureALG: unknown format"
     toASN1 (SignatureALG_Unknown oid) = \xs -> Start Sequence:OID oid:Null:End Sequence:xs
     toASN1 signatureAlg@(SignatureALG hashAlg PubKeyALG_RSAPSS) = \xs -> Start Sequence:OID [1,2,840,113549,1,1,10]:Start Sequence:Start (Container Context 0):Start Sequence:OID (sigOID signatureAlg):End Sequence:End (Container Context 0):Start (Container Context 1): Start Sequence:OID [1,2,840,113549,1,1,8]:Start Sequence:OID (sigOID signatureAlg):End Sequence:End Sequence:End (Container Context 1):Start (Container Context 2):IntVal (saltLen hashAlg):End (Container Context 2):End Sequence:End Sequence:xs
+    toASN1 signatureAlg@(SignatureALG_IntrinsicHash _) = \xs -> Start Sequence:OID (sigOID signatureAlg):End Sequence:xs
     toASN1 signatureAlg = \xs -> Start Sequence:OID (sigOID signatureAlg):Null:End Sequence:xs

--- a/x509/Data/X509/AlgorithmIdentifier.hs
+++ b/x509/Data/X509/AlgorithmIdentifier.hs
@@ -102,7 +102,10 @@ saltLen _          = error "toASN1: X509.SignatureAlg.HashAlg: Unknown hash"
 
 instance ASN1Object SignatureALG where
     fromASN1 (Start Sequence:OID oid:Null:End Sequence:xs) =
-        Right (oidSig oid, xs)
+        case oidSig oid of
+            SignatureALG_IntrinsicHash _ ->
+                Left "fromASN1: X509.SignatureALG: EdDSA requires absent parameter"
+            signatureAlg -> Right (signatureAlg, xs)
     fromASN1 (Start Sequence:OID oid:End Sequence:xs) =
         Right (oidSig oid, xs)
     fromASN1 (Start Sequence:OID [1,2,840,113549,1,1,10]:Start Sequence:Start _:Start Sequence:OID hash1:End Sequence:End _:Start _:Start Sequence:OID [1,2,840,113549,1,1,8]:Start Sequence:OID _hash2:End Sequence:End Sequence:End _:Start _: IntVal _iv: End _: End Sequence : End Sequence:xs) =


### PR DESCRIPTION
Fix for the issue explained in #103.

In [RFC 8410 section 3](https://tools.ietf.org/html/rfc8410#section-3):
> For all of the OIDs, the parameters MUST be absent.

So this must be done for `SignatureALG`.

This is a new algorithm and other implementations are strict on this, so parsing in `x509` can be strict too.