### PR TITLE
Use numBytes to get RSA key size

### DIFF
--- a/x509-store/Data/X509/Memory.hs
+++ b/x509-store/Data/X509/Memory.hs
@@ -22,6 +22,7 @@ import qualified Data.X509 as X509
 import           Data.X509.EC as X509
 import Data.PEM (pemParseBS, pemContent, pemName, PEM)
 import qualified Data.ByteString as B
+import           Crypto.Number.Basic (numBytes)
 import           Crypto.Number.Serialize (os2ip)
 import qualified Crypto.PubKey.DSA as DSA
 import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
@@ -192,8 +193,7 @@ rsaFromASN1 (Start Sequence
              : End Sequence
              : xs) = Right (privKey, xs)
   where
-    calculate_modulus m i = if (2 ^ (i * 8)) > m then i else calculate_modulus m (i+1)
-    pubKey  = RSA.PublicKey { RSA.public_size = calculate_modulus n 1
+    pubKey  = RSA.PublicKey { RSA.public_size = numBytes n
                             , RSA.public_n    = n
                             , RSA.public_e    = e
                             }

--- a/x509/Data/X509/PublicKey.hs
+++ b/x509/Data/X509/PublicKey.hs
@@ -35,6 +35,7 @@ import qualified Crypto.PubKey.Curve25519 as X25519
 import qualified Crypto.PubKey.Curve448   as X448
 import qualified Crypto.PubKey.Ed25519    as Ed25519
 import qualified Crypto.PubKey.Ed448      as Ed448
+import           Crypto.Number.Basic (numBytes)
 import           Crypto.Number.Serialize (os2ip)
 import Data.Word
 
@@ -234,11 +235,10 @@ rsaPubFromASN1 :: [ASN1] -> Either String (RSA.PublicKey, [ASN1])
 rsaPubFromASN1 (Start Sequence:IntVal smodulus:IntVal pubexp:End Sequence:xs) =
     Right (pub, xs)
   where
-    pub = RSA.PublicKey { RSA.public_size = calculate_modulus modulus 1
+    pub = RSA.PublicKey { RSA.public_size = numBytes modulus
                         , RSA.public_n    = modulus
                         , RSA.public_e    = pubexp
                         }
-    calculate_modulus n i = if (2 ^ (i * 8)) > n then i else calculate_modulus n (i+1)
     -- some bad implementation will not serialize ASN.1 integer properly, leading
     -- to negative modulus. if that's the case, we correct it.
     modulus = toPositive smodulus


### PR DESCRIPTION
Now that `numBytes` is available it can replace the `calculate_modulus` loops.