### PR TITLE
Support server name validation using IP Address

### DIFF
--- a/x509-store/crypton-x509-store.cabal
+++ b/x509-store/crypton-x509-store.cabal
@@ -1,11 +1,11 @@
-Name:                x509-store
+Name:                crypton-x509-store
 version:             1.6.9
 Description:         X.509 collection accessing and storing methods for certificate, crl, exception list
 License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Synopsis:            X.509 collection accessing and storing methods
 Build-Type:          Simple
 Category:            Data
@@ -24,8 +24,8 @@ Library
                    , pem >= 0.1 && < 0.3
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
-                   , cryptonite
-                   , x509 >= 1.7.2
+                   , crypton
+                   , crypton-x509 >= 1.7.2
   Exposed-modules:   Data.X509.CertificateStore
                      Data.X509.File
                      Data.X509.Memory
@@ -40,8 +40,8 @@ Test-Suite test-x509-store
                    , bytestring
                    , tasty
                    , tasty-hunit
-                   , x509
-                   , x509-store
+                   , crypton-x509
+                   , crypton-x509-store
   ghc-options:       -Wall
 
 source-repository head

--- a/x509-store/crypton-x509-store.cabal
+++ b/x509-store/crypton-x509-store.cabal
@@ -10,7 +10,7 @@ Synopsis:            X.509 collection accessing and storing methods
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Library

--- a/x509-system/crypton-x509-system.cabal
+++ b/x509-system/crypton-x509-system.cabal
@@ -10,7 +10,7 @@ Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Library

--- a/x509-system/crypton-x509-system.cabal
+++ b/x509-system/crypton-x509-system.cabal
@@ -1,4 +1,4 @@
-Name:                x509-system
+Name:                crypton-x509-system
 version:             1.6.7
 Synopsis:            Handle per-operating-system X.509 accessors and storage
 Description:         System X.509 handling for accessing operating system dependents store and other storage methods
@@ -6,7 +6,7 @@ License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
@@ -23,8 +23,8 @@ Library
                    , filepath
                    , process
                    , pem >= 0.1 && < 0.3
-                   , x509 >= 1.6
-                   , x509-store >= 1.6.2
+                   , crypton-x509 >= 1.6
+                   , crypton-x509-store >= 1.6.2
   Exposed-modules:   System.X509
                      System.X509.Unix
                      System.X509.MacOS
@@ -39,5 +39,5 @@ Library
 
 source-repository head
   type:     git
-  location: git://github.com/vincenthz/hs-certificate
+  location: https://github.com/kazu-yamamoto/crypton-certificate
   subdir:   x509-system

--- a/x509-util/crypton-x509-util.cabal
+++ b/x509-util/crypton-x509-util.cabal
@@ -1,11 +1,11 @@
-Name:                x509-util
+Name:                crypton-x509-util
 version:             1.6.6
 Description:         utility to parse, show, validate, sign and produce X509 certificates and chain.
 License:             BSD3
 License-file:        LICENSE
-Copyright:           Vincent Hanquez <vincent@snarc.org>
+Copyright:           Vincent Hanquez <vincent@snar.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Synopsis:            Utility for X509 certificate and chain
 Build-Type:          Simple
 Category:            Data
@@ -13,26 +13,26 @@ stability:           experimental
 Homepage:            http://github.com/vincenthz/hs-certificate
 Cabal-Version:       >= 1.10
 
-Executable           x509-util
+Executable           crypton-x509-util
   Default-Language:  Haskell2010
   Main-Is:           Certificate.hs
   hs-source-dirs:    src
   Buildable:         True
   Build-depends:     base >= 3 && < 5
                    , bytestring
-                   , x509 >= 1.7.1
-                   , x509-store
-                   , x509-system
-                   , x509-validation >= 1.6.3
+                   , crypton-x509 >= 1.7.1
+                   , crypton-x509-store
+                   , crypton-x509-system
+                   , crypton-x509-validation >= 1.6.3
                    , asn1-types >= 0.3
                    , asn1-encoding
                    , pem
                    , directory
                    , hourglass
                    , memory
-                   , cryptonite
+                   , crypton
 
 source-repository head
   type:     git
-  location: git://github.com/vincenthz/hs-certificate
+  location: https://github.com/kazu-yamamoto/crypton-certificate
   subdir:   x509-util

--- a/x509-util/crypton-x509-util.cabal
+++ b/x509-util/crypton-x509-util.cabal
@@ -10,7 +10,7 @@ Synopsis:            Utility for X509 certificate and chain
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Executable           crypton-x509-util

--- a/x509-validation/Data/X509/Validation.hs
+++ b/x509-validation/Data/X509/Validation.hs
@@ -9,6 +9,7 @@
 --
 -- Follows RFC5280 / RFC6818
 --
+{-# LANGUAGE OverloadedStrings #-}
 module Data.X509.Validation
     (
       module Data.X509.Validation.Types
@@ -47,10 +48,11 @@ import System.Hourglass
 import Data.Maybe
 import Data.List
 import Data.ByteString (unpack)
-import Data.Function ((&))
-import Data.Word (Word8)
-import Text.ParserCombinators.ReadP
-
+import Data.Bits
+import Data.Word (Word16, Word8)
+import Foundation.Network.IPv4 as IPv4 (ipv4Parser, IPv4, fromTuple)
+import Foundation.Network.IPv6 as IPv6 (ipv6Parser, IPv6, fromTuple)
+import Foundation.Parser
 
 -- | Possible reason of certificate and chain failure.
 --
@@ -338,33 +340,39 @@ getNames cert = (commonName >>= asn1CharacterToString, altNames)
             where unAltName (AltNameDNS s) = Just s
                   unAltName _              = Nothing
 
-getIPs :: Certificate -> [[Word8]]
+data IPAddress = IPv4Address IPv4
+               | IPv6Address IPv6
+  deriving Eq
+
+getIPs :: Certificate -> [IPAddress]
 getIPs cert = fromMaybe [] (toAltName <$> (extensionGet $ certExtensions cert))
   where toAltName (ExtSubjectAltName names) = catMaybes $ map unAltName names
-          where unAltName (AltNameIP s) = Just $ unpack s
-                unAltName _             = Nothing
 
-parseIPAddress :: HostName -> Maybe [Word8]
-parseIPAddress host = case readP_to_S (ipv4Parser <* eof) host of
-                        [(ipv4, _)] -> Just ipv4
-                        _ -> Nothing
+        unAltName (AltNameIP s) = case unpack s of
+                                    [a,b,c,d] -> Just $ IPv4Address $ IPv4.fromTuple (a,b,c,d)
+                                    [a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p] ->
+                                      Just $ IPv6Address $ IPv6.fromTuple ( fuse a b, fuse c d
+                                                                          , fuse e f, fuse g h
+                                                                          , fuse i j, fuse k l
+                                                                          , fuse m n, fuse o p)
+                                    _ -> Nothing
+        unAltName _             = Nothing
 
-ipv4Parser :: ReadP [Word8]
-ipv4Parser = do
-  let digits = munch1 (\c -> c >= '0' && c <= '9')
-  first <- digits
-  _ <- char '.'
-  second <- digits
-  _ <- char '.'
-  third <- digits
-  _ <- char '.'
-  fourth <- digits
-  [first, second, third, fourth]
-    & map (read :: String -> Integer) -- reading to Word8 would overflow without error
-    & map (\w -> if w <= 255
-                 then return (fromIntegral w)
-                 else pfail)
-    & sequence
+        fuse :: Word8 -> Word8 -> Word16
+        fuse a b = shiftL (fromIntegral a) 8 .|. (fromIntegral b)
+
+parseIPAddress :: HostName -> Maybe IPAddress
+parseIPAddress host = either (const Nothing) Just
+                      $ parseOnly (parser <* endOfInput) host
+                      where
+                        parser = IPv4Address <$> ipv4Parser
+                                     <|> IPv6Address <$> ipv6Parser
+
+                        endOfInput = do
+                          nextChar <- peek
+                          case nextChar of
+                            Nothing -> return ()
+                            _ -> reportError $ Satisfy $ Just "expected end of input"
 
 -- | Validate that the fqhn is matched by at least one name in the certificate.
 -- If the subjectAltname extension is present, then the certificate commonName

--- a/x509-validation/Data/X509/Validation.hs
+++ b/x509-validation/Data/X509/Validation.hs
@@ -32,7 +32,6 @@ module Data.X509.Validation
     , module Data.X509.Validation.Signature
     ) where
 
-import Control.Applicative
 import Control.Monad (when)
 import Data.Default.Class
 import Data.ASN1.Types
@@ -47,6 +46,11 @@ import Data.Hourglass
 import System.Hourglass
 import Data.Maybe
 import Data.List
+import Data.ByteString (unpack)
+import Data.Function ((&))
+import Data.Word (Word8)
+import Text.ParserCombinators.ReadP
+
 
 -- | Possible reason of certificate and chain failure.
 --
@@ -334,10 +338,39 @@ getNames cert = (commonName >>= asn1CharacterToString, altNames)
             where unAltName (AltNameDNS s) = Just s
                   unAltName _              = Nothing
 
+getIPs :: Certificate -> [[Word8]]
+getIPs cert = fromMaybe [] (toAltName <$> (extensionGet $ certExtensions cert))
+  where toAltName (ExtSubjectAltName names) = catMaybes $ map unAltName names
+          where unAltName (AltNameIP s) = Just $ unpack s
+                unAltName _             = Nothing
+
+parseIPAddress :: HostName -> Maybe [Word8]
+parseIPAddress host = case readP_to_S (ipv4Parser <* eof) host of
+                        [(ipv4, _)] -> Just ipv4
+                        _ -> Nothing
+
+ipv4Parser :: ReadP [Word8]
+ipv4Parser = do
+  let digits = munch1 (\c -> c >= '0' && c <= '9')
+  first <- digits
+  _ <- char '.'
+  second <- digits
+  _ <- char '.'
+  third <- digits
+  _ <- char '.'
+  fourth <- digits
+  [first, second, third, fourth]
+    & map (read :: String -> Integer) -- reading to Word8 would overflow without error
+    & map (\w -> if w <= 255
+                 then return (fromIntegral w)
+                 else pfail)
+    & sequence
+
 -- | Validate that the fqhn is matched by at least one name in the certificate.
 -- If the subjectAltname extension is present, then the certificate commonName
--- is ignored, and only the DNS names, if any, in the subjectAltName are
--- considered.  Otherwise, the commonName from the subjectDN is used.
+-- is ignored, and only the DNS names and IP Addresses, if any, in the
+-- subjectAltName are considered.  Otherwise, the commonName from the subjectDN
+-- is used.
 --
 -- Note that DNS names in the subjectAltName are in IDNA A-label form. If the
 -- destination hostname is a UTF-8 name, it must be provided to the TLS context
@@ -345,7 +378,11 @@ getNames cert = (commonName >>= asn1CharacterToString, altNames)
 validateCertificateName :: HostName -> Certificate -> [FailedReason]
 validateCertificateName fqhn cert
     | not $ null altNames =
-        findMatch [] $ map matchDomain altNames
+        case parseIPAddress fqhn of
+          Nothing -> findMatch [] $ map matchDomain altNames
+          Just ip -> if elem ip (getIPs cert)
+                     then []
+                     else [NameMismatch fqhn]
     | otherwise =
         case commonName of
             Nothing -> [NoCommonName]

--- a/x509-validation/Tests/Tests.hs
+++ b/x509-validation/Tests/Tests.hs
@@ -574,6 +574,8 @@ treeWithAlg groupName alg = withResource (initData alg) freeData $ \res ->
           , testSubjectAltName res "www.example.com"  "cn-not-used" True [NameMismatch "cn-not-used"]
           , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.1" True []
           , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.2" True [NameMismatch "10.0.0.2"]
+          , testSubjectAltNameIP res (BS.pack [255,255,255,255]) "255.255.255.255" True []
+          , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "266.0.0.1" True [NameMismatch "266.0.0.1"] -- 266 read in Word8 is 10
           , testGroup "disabled"
               [ testSubjectAltName res "www.example.com"  "www.example.com"  False []
               , testSubjectAltName res "www.example.com"  "www2.example.com" False []

--- a/x509-validation/Tests/Tests.hs
+++ b/x509-validation/Tests/Tests.hs
@@ -576,8 +576,7 @@ treeWithAlg groupName alg = withResource (initData alg) freeData $ \res ->
           , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.1" True []
           , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.2" True [NameMismatch "10.0.0.2"]
           , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.1.example.com" True [NameMismatch "10.0.0.1.example.com"]
-          -- This will have to be fixed in parser library, https://github.com/haskell-foundation/foundation/issues/523
-          -- , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "266.0.0.1" True [NameMismatch "266.0.0.1"] -- 266 read in Word8 is 10
+          , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "266.0.0.1" True [NameMismatch "266.0.0.1"] -- 266 read in Word8 is 10, hence this test
 
           , testSubjectAltNameIP res (BS.pack [0x20,0x01,0x0d,0xb8,0x85,0xa3,0,0,0,0,0x8a,0x2e,0x03,0x70,0x73,0x34]) "2001:0db8:85a3:0000:0000:8a2e:0370:7334" True []
           , testSubjectAltNameIP res (BS.pack [0x20,0x01,0x0d,0xb8,0x85,0xa3,0,0,0,0,0x8a,0x2e,0x03,0x70,0x73,0x34]) "2001:0db8:85a3::8a2e:0370:7334" True []

--- a/x509-validation/Tests/Tests.hs
+++ b/x509-validation/Tests/Tests.hs
@@ -17,6 +17,8 @@ import Data.X509
 import Data.X509.CertificateStore
 import Data.X509.Validation
 
+import qualified Data.ByteString as BS
+
 import Data.Hourglass
 import System.Hourglass
 
@@ -370,6 +372,31 @@ testSubjectAltName res san hostname check expected = testWithRes res caseName $ 
                               , AltNameDNS    "dummy2"
                               ]
 
+-- | Tests certificate SubjectAltName against expected IP Address, with or
+-- without 'checkFQHN'.
+testSubjectAltNameIP :: IO (RData pub priv) -- ^ Common test resources
+                     -> BS.ByteString              -- ^ Certificate SubjectAltName
+                     -> HostName            -- ^ Connection identification
+                     -> Bool                -- ^ Value for 'checkFQHN'
+                     -> [FailedReason]      -- ^ Expected validation result
+                     -> TestTree
+testSubjectAltNameIP res ip hostname check expected = testWithRes res caseName $ \rd -> do
+    pair <- mkCertificate 2 100 dn (present rd) (ext:leafStdExts) (CA $ intermediate rd) (keys1 rd)
+    assertValidationResult rd checks hostname [pair, intermediate rd] expected
+  where
+    caseName = if null hostname then "empty" else hostname
+    checks = defaultChecks { checkFQHN = check }
+    dn = mkDn "cn-not-used" -- this CN value is to be tested too
+                            -- (to make sure CN is *not* considered when a
+                            -- SubjectAltName exists)
+    ext = mkExtension False $
+            -- wraps test value with other values
+            ExtSubjectAltName [ AltNameDNS    "dummy1"
+                              , AltNameRFC822 "test@example.com"
+                              , AltNameIP     ip
+                              , AltNameDNS    "dummy2"
+                              ]
+
 -- | Tests 'checkLeafKeyUsage'.
 testLeafKeyUsage :: IO (RData pub priv) -- ^ Common test resources
                  -> TestName            -- ^ Case name
@@ -545,6 +572,8 @@ treeWithAlg groupName alg = withResource (initData alg) freeData $ \res ->
               , testSubjectAltName res "*"             "single"            True [NameMismatch "single"] -- InvalidWildcard
               ]
           , testSubjectAltName res "www.example.com"  "cn-not-used" True [NameMismatch "cn-not-used"]
+          , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.1" True []
+          , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.2" True [NameMismatch "10.0.0.2"]
           , testGroup "disabled"
               [ testSubjectAltName res "www.example.com"  "www.example.com"  False []
               , testSubjectAltName res "www.example.com"  "www2.example.com" False []

--- a/x509-validation/Tests/Tests.hs
+++ b/x509-validation/Tests/Tests.hs
@@ -572,10 +572,17 @@ treeWithAlg groupName alg = withResource (initData alg) freeData $ \res ->
               , testSubjectAltName res "*"             "single"            True [NameMismatch "single"] -- InvalidWildcard
               ]
           , testSubjectAltName res "www.example.com"  "cn-not-used" True [NameMismatch "cn-not-used"]
+
           , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.1" True []
           , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.2" True [NameMismatch "10.0.0.2"]
-          , testSubjectAltNameIP res (BS.pack [255,255,255,255]) "255.255.255.255" True []
-          , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "266.0.0.1" True [NameMismatch "266.0.0.1"] -- 266 read in Word8 is 10
+          , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "10.0.0.1.example.com" True [NameMismatch "10.0.0.1.example.com"]
+          -- This will have to be fixed in parser library, https://github.com/haskell-foundation/foundation/issues/523
+          -- , testSubjectAltNameIP res (BS.pack [10,0,0,1]) "266.0.0.1" True [NameMismatch "266.0.0.1"] -- 266 read in Word8 is 10
+
+          , testSubjectAltNameIP res (BS.pack [0x20,0x01,0x0d,0xb8,0x85,0xa3,0,0,0,0,0x8a,0x2e,0x03,0x70,0x73,0x34]) "2001:0db8:85a3:0000:0000:8a2e:0370:7334" True []
+          , testSubjectAltNameIP res (BS.pack [0x20,0x01,0x0d,0xb8,0x85,0xa3,0,0,0,0,0x8a,0x2e,0x03,0x70,0x73,0x34]) "2001:0db8:85a3::8a2e:0370:7334" True []
+          , testSubjectAltNameIP res (BS.pack [0x20,0x01,0x0d,0xb8,0x85,0xa3,0,0,0,0,0x8a,0x2e,0x03,0x70,0x73,0x34]) "2001:0db8:85a3:0:0:8a2e:0370:7334" True []
+          , testSubjectAltNameIP res (BS.pack [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]) "::1" True []
           , testGroup "disabled"
               [ testSubjectAltName res "www.example.com"  "www.example.com"  False []
               , testSubjectAltName res "www.example.com"  "www2.example.com" False []

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -10,7 +10,7 @@ Synopsis:            X.509 Certificate and CRL validation
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Library

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -28,6 +28,7 @@ Library
                    , crypton-x509 >= 1.7.5
                    , crypton-x509-store >= 1.6
                    , crypton >= 0.24
+                   , foundation >= 0.0.21
   Exposed-modules:   Data.X509.Validation
   Other-modules:     Data.X509.Validation.Signature
                      Data.X509.Validation.Fingerprint

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -28,7 +28,7 @@ Library
                    , crypton-x509 >= 1.7.5
                    , crypton-x509-store >= 1.6
                    , crypton >= 0.24
-                   , foundation >= 0.0.21
+                   , foundation >= 0.0.25
   Exposed-modules:   Data.X509.Validation
   Other-modules:     Data.X509.Validation.Signature
                      Data.X509.Validation.Fingerprint

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -1,11 +1,11 @@
-Name:                x509-validation
+Name:                crypton-x509-validation
 version:             1.6.12
 Description:         X.509 Certificate and CRL validation. please see README
 License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Synopsis:            X.509 Certificate and CRL validation
 Build-Type:          Simple
 Category:            Data
@@ -25,9 +25,9 @@ Library
                    , pem >= 0.1
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
-                   , x509 >= 1.7.5
-                   , x509-store >= 1.6
-                   , cryptonite >= 0.24
+                   , crypton-x509 >= 1.7.5
+                   , crypton-x509-store >= 1.6
+                   , crypton >= 0.24
   Exposed-modules:   Data.X509.Validation
   Other-modules:     Data.X509.Validation.Signature
                      Data.X509.Validation.Fingerprint
@@ -50,13 +50,13 @@ Test-Suite test-x509-validation
                    , hourglass
                    , asn1-types
                    , asn1-encoding
-                   , x509 >= 1.7.1
-                   , x509-store
-                   , x509-validation
-                   , cryptonite
+                   , crypton-x509 >= 1.7.1
+                   , crypton-x509-store
+                   , crypton-x509-validation
+                   , crypton
   ghc-options:       -Wall
 
 source-repository head
   type:     git
-  location: git://github.com/vincenthz/hs-certificate
+  location: https://github.com/kazu-yamamoto/crypton-certificate
   subdir:   x509-validation

--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -10,7 +10,7 @@ Synopsis:            X509 reader and writer
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Library

--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -1,11 +1,11 @@
-Name:                x509
+Name:                crypton-x509
 version:             1.7.6
 Description:         X509 reader and writer. please see README
 License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Synopsis:            X509 reader and writer
 Build-Type:          Simple
 Category:            Data
@@ -25,7 +25,7 @@ Library
                    , asn1-types >= 0.3.1 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
                    , asn1-parse >= 0.9.3 && < 0.10
-                   , cryptonite >= 0.24
+                   , crypton >= 0.24
   Exposed-modules:   Data.X509
                      Data.X509.EC
   Other-modules:     Data.X509.Internal
@@ -55,10 +55,10 @@ Test-Suite test-x509
                    , hourglass
                    , asn1-types
                    , x509
-                   , cryptonite
+                   , crypton
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures
 
 source-repository head
   type:     git
-  location: git://github.com/vincenthz/hs-certificate
+  location: https://github.com/kazu-yamamoto/crypton-certificate
   subdir:   x509


### PR DESCRIPTION
Fixes #90 

This PR uses foundation for parsing IP address from hostname. The parser can overflow without any errors which may be seen as a vulnerability. I have opened another PR (haskell-foundation/foundation#524) to fix it.

I would've written the parser here using ReadP, but parsing IPv6 was getting very involved so I decided to use foundation. 