### PR TITLE
Avoid error inside a pure value, and use instead the IO Monad's fail

### DIFF
--- a/x509-store/Data/X509/File.hs
+++ b/x509-store/Data/X509/File.hs
@@ -16,7 +16,7 @@ import qualified Data.ByteString.Lazy as L
 readPEMs :: FilePath -> IO [PEM]
 readPEMs filepath = do
     content <- L.readFile filepath
-    return $ either error id $ pemParseLBS content
+    either fail return $ pemParseLBS content
 
 -- | return all the signed objects in a file.
 --


### PR DESCRIPTION
Otherwise, to catch this runtime error, you'd be forced to use something like [Control.Exception.evaluate](https://hackage.haskell.org/package/base-4.12.0.0/docs/Control-Exception.html#g:8)