### PR TITLE
Turn error call in readPEM into an Exception

### DIFF
--- a/x509-store/Data/X509/File.hs
+++ b/x509-store/Data/X509/File.hs
@@ -1,9 +1,11 @@
 module Data.X509.File
     ( readSignedObject
     , readKeyFile
+    , PEMError (..)
     ) where
 
 import Control.Applicative
+import Control.Exception (Exception (..), throw)
 import Data.ASN1.Types
 import Data.ASN1.BinaryEncoding
 import Data.ASN1.Encoding
@@ -13,10 +15,16 @@ import           Data.X509.Memory (pemToKey)
 import Data.PEM (pemParseLBS, pemContent, pemName, PEM)
 import qualified Data.ByteString.Lazy as L
 
+newtype PEMError = PEMError {displayPEMError :: String}
+  deriving Show
+
+instance Exception PEMError where
+  displayException = displayPEMError
+
 readPEMs :: FilePath -> IO [PEM]
 readPEMs filepath = do
     content <- L.readFile filepath
-    return $ either error id $ pemParseLBS content
+    either (throw . PEMError) pure $ pemParseLBS content
 
 -- | return all the signed objects in a file.
 --


### PR DESCRIPTION
This makes it easier to handle errors when reading certificate files.