### PR TITLE
x509: Bump requirements to GHC 7.8 and transformers 0.4 series

### DIFF
--- a/x509/Data/X509/Internal.hs
+++ b/x509/Data/X509/Internal.hs
@@ -5,7 +5,6 @@
 -- Stability   : experimental
 -- Portability : unknown
 --
-{-# LANGUAGE CPP #-}
 module Data.X509.Internal
     ( module Data.ASN1.Parse
     , asn1Container
@@ -17,18 +16,11 @@ module Data.X509.Internal
 
 import Data.ASN1.Types
 import Data.ASN1.Parse
+import Control.Monad.Trans.Except
 
-#if MIN_VERSION_mtl(2,2,1)
-import Control.Monad.Except
 runErrT :: ExceptT e m a -> m (Either e a)
 runErrT = runExceptT
 type ErrT = ExceptT
-#else
-import Control.Monad.Error
-runErrT :: ErrorT e m a -> m (Either e a)
-runErrT = runErrorT
-type ErrT = ErrorT
-#endif
 
 -- | create a container around the stream of ASN1
 asn1Container :: ASN1ConstructionType -> [ASN1] -> [ASN1]

--- a/x509/x509.cabal
+++ b/x509/x509.cabal
@@ -15,10 +15,10 @@ Cabal-Version:       >= 1.10
 
 Library
   Default-Language:  Haskell2010
-  Build-Depends:     base >= 3 && < 5
+  Build-Depends:     base >= 4.7 && < 5
                    , bytestring
                    , memory
-                   , mtl
+                   , transformers >= 0.4
                    , containers
                    , hourglass
                    , pem >= 0.1


### PR DESCRIPTION
This fixes compatibility with transformers 0.6. Tested using

    cabal test --constraint='transformers>=0.6' all

and the following `cabal.project`:

    packages: x509 x509-store x509-system x509-util x509-validation
