### PR TITLE
Update for `data-default-0.8`

### DIFF
--- a/x509-store/crypton-x509-store.cabal
+++ b/x509-store/crypton-x509-store.cabal
@@ -1,11 +1,11 @@
-Name:                x509-store
+Name:                crypton-x509-store
 version:             1.6.9
 Description:         X.509 collection accessing and storing methods for certificate, crl, exception list
 License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Synopsis:            X.509 collection accessing and storing methods
 Build-Type:          Simple
 Category:            Data
@@ -24,8 +24,8 @@ Library
                    , pem >= 0.1 && < 0.3
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
-                   , cryptonite
-                   , x509 >= 1.7.2
+                   , crypton
+                   , crypton-x509 >= 1.7.2
   Exposed-modules:   Data.X509.CertificateStore
                      Data.X509.File
                      Data.X509.Memory
@@ -40,8 +40,8 @@ Test-Suite test-x509-store
                    , bytestring
                    , tasty
                    , tasty-hunit
-                   , x509
-                   , x509-store
+                   , crypton-x509
+                   , crypton-x509-store
   ghc-options:       -Wall
 
 source-repository head

--- a/x509-store/crypton-x509-store.cabal
+++ b/x509-store/crypton-x509-store.cabal
@@ -10,7 +10,7 @@ Synopsis:            X.509 collection accessing and storing methods
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Library

--- a/x509-system/crypton-x509-system.cabal
+++ b/x509-system/crypton-x509-system.cabal
@@ -10,7 +10,7 @@ Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Library

--- a/x509-system/crypton-x509-system.cabal
+++ b/x509-system/crypton-x509-system.cabal
@@ -1,4 +1,4 @@
-Name:                x509-system
+Name:                crypton-x509-system
 version:             1.6.7
 Synopsis:            Handle per-operating-system X.509 accessors and storage
 Description:         System X.509 handling for accessing operating system dependents store and other storage methods
@@ -6,7 +6,7 @@ License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
@@ -23,8 +23,8 @@ Library
                    , filepath
                    , process
                    , pem >= 0.1 && < 0.3
-                   , x509 >= 1.6
-                   , x509-store >= 1.6.2
+                   , crypton-x509 >= 1.6
+                   , crypton-x509-store >= 1.6.2
   Exposed-modules:   System.X509
                      System.X509.Unix
                      System.X509.MacOS
@@ -39,5 +39,5 @@ Library
 
 source-repository head
   type:     git
-  location: git://github.com/vincenthz/hs-certificate
+  location: https://github.com/kazu-yamamoto/crypton-certificate
   subdir:   x509-system

--- a/x509-util/crypton-x509-util.cabal
+++ b/x509-util/crypton-x509-util.cabal
@@ -1,11 +1,11 @@
-Name:                x509-util
+Name:                crypton-x509-util
 version:             1.6.6
 Description:         utility to parse, show, validate, sign and produce X509 certificates and chain.
 License:             BSD3
 License-file:        LICENSE
-Copyright:           Vincent Hanquez <vincent@snarc.org>
+Copyright:           Vincent Hanquez <vincent@snar.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Synopsis:            Utility for X509 certificate and chain
 Build-Type:          Simple
 Category:            Data
@@ -13,26 +13,26 @@ stability:           experimental
 Homepage:            http://github.com/vincenthz/hs-certificate
 Cabal-Version:       >= 1.10
 
-Executable           x509-util
+Executable           crypton-x509-util
   Default-Language:  Haskell2010
   Main-Is:           Certificate.hs
   hs-source-dirs:    src
   Buildable:         True
   Build-depends:     base >= 3 && < 5
                    , bytestring
-                   , x509 >= 1.7.1
-                   , x509-store
-                   , x509-system
-                   , x509-validation >= 1.6.3
+                   , crypton-x509 >= 1.7.1
+                   , crypton-x509-store
+                   , crypton-x509-system
+                   , crypton-x509-validation >= 1.6.3
                    , asn1-types >= 0.3
                    , asn1-encoding
                    , pem
                    , directory
                    , hourglass
                    , memory
-                   , cryptonite
+                   , crypton
 
 source-repository head
   type:     git
-  location: git://github.com/vincenthz/hs-certificate
+  location: https://github.com/kazu-yamamoto/crypton-certificate
   subdir:   x509-util

--- a/x509-util/crypton-x509-util.cabal
+++ b/x509-util/crypton-x509-util.cabal
@@ -10,7 +10,7 @@ Synopsis:            Utility for X509 certificate and chain
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Executable           crypton-x509-util

--- a/x509-validation/Data/X509/Validation.hs
+++ b/x509-validation/Data/X509/Validation.hs
@@ -34,7 +34,7 @@ module Data.X509.Validation
 
 import Control.Applicative
 import Control.Monad (when)
-import Data.Default.Class
+import Data.Default
 import Data.ASN1.Types
 import Data.Char (toLower)
 import Data.X509

--- a/x509-validation/Data/X509/Validation/Cache.hs
+++ b/x509-validation/Data/X509/Validation/Cache.hs
@@ -22,7 +22,7 @@ module Data.X509.Validation.Cache
     ) where
 
 import Control.Concurrent
-import Data.Default.Class
+import Data.Default
 import Data.X509
 import Data.X509.Validation.Types
 import Data.X509.Validation.Fingerprint

--- a/x509-validation/Tests/Tests.hs
+++ b/x509-validation/Tests/Tests.hs
@@ -10,7 +10,7 @@ import qualified Crypto.PubKey.DSA        as DSA
 import qualified Crypto.PubKey.ECC.Types  as ECC
 import qualified Crypto.PubKey.RSA.PSS    as PSS
 
-import Data.Default.Class
+import Data.Default
 import Data.Monoid
 import Data.String (fromString)
 import Data.X509

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -10,7 +10,7 @@ Synopsis:            X.509 Certificate and CRL validation
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Library

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -21,7 +21,7 @@ Library
                    , mtl
                    , containers
                    , hourglass
-                   , data-default-class
+                   , data-default >= 0.8
                    , pem >= 0.1
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
@@ -44,7 +44,7 @@ Test-Suite test-x509-validation
   Build-Depends:     base >= 3 && < 5
                    , bytestring
                    , memory
-                   , data-default-class
+                   , data-default
                    , tasty
                    , tasty-hunit
                    , hourglass

--- a/x509-validation/crypton-x509-validation.cabal
+++ b/x509-validation/crypton-x509-validation.cabal
@@ -1,11 +1,11 @@
-Name:                x509-validation
+Name:                crypton-x509-validation
 version:             1.6.12
 Description:         X.509 Certificate and CRL validation. please see README
 License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Synopsis:            X.509 Certificate and CRL validation
 Build-Type:          Simple
 Category:            Data
@@ -25,9 +25,9 @@ Library
                    , pem >= 0.1
                    , asn1-types >= 0.3 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
-                   , x509 >= 1.7.5
-                   , x509-store >= 1.6
-                   , cryptonite >= 0.24
+                   , crypton-x509 >= 1.7.5
+                   , crypton-x509-store >= 1.6
+                   , crypton >= 0.24
   Exposed-modules:   Data.X509.Validation
   Other-modules:     Data.X509.Validation.Signature
                      Data.X509.Validation.Fingerprint
@@ -50,13 +50,13 @@ Test-Suite test-x509-validation
                    , hourglass
                    , asn1-types
                    , asn1-encoding
-                   , x509 >= 1.7.1
-                   , x509-store
-                   , x509-validation
-                   , cryptonite
+                   , crypton-x509 >= 1.7.1
+                   , crypton-x509-store
+                   , crypton-x509-validation
+                   , crypton
   ghc-options:       -Wall
 
 source-repository head
   type:     git
-  location: git://github.com/vincenthz/hs-certificate
+  location: https://github.com/kazu-yamamoto/crypton-certificate
   subdir:   x509-validation

--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -54,7 +54,7 @@ Test-Suite test-x509
                    , tasty-quickcheck
                    , hourglass
                    , asn1-types
-                   , x509
+                   , crypton-x509
                    , crypton
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures
 

--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -10,7 +10,7 @@ Synopsis:            X509 reader and writer
 Build-Type:          Simple
 Category:            Data
 stability:           experimental
-Homepage:            http://github.com/vincenthz/hs-certificate
+Homepage:            https://github.com/kazu-yamamoto/crypton-certificate
 Cabal-Version:       >= 1.10
 
 Library

--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -1,5 +1,5 @@
 Name:                crypton-x509
-version:             1.7.6
+version:             1.7.7
 Description:         X509 reader and writer. please see README
 License:             BSD3
 License-file:        LICENSE

--- a/x509/crypton-x509.cabal
+++ b/x509/crypton-x509.cabal
@@ -1,11 +1,11 @@
-Name:                x509
+Name:                crypton-x509
 version:             1.7.6
 Description:         X509 reader and writer. please see README
 License:             BSD3
 License-file:        LICENSE
 Copyright:           Vincent Hanquez <vincent@snarc.org>
 Author:              Vincent Hanquez <vincent@snarc.org>
-Maintainer:          Vincent Hanquez <vincent@snarc.org>
+Maintainer:          Kazu Yamamoto <kazu@iij.ad.jp>
 Synopsis:            X509 reader and writer
 Build-Type:          Simple
 Category:            Data
@@ -25,7 +25,7 @@ Library
                    , asn1-types >= 0.3.1 && < 0.4
                    , asn1-encoding >= 0.9 && < 0.10
                    , asn1-parse >= 0.9.3 && < 0.10
-                   , cryptonite >= 0.24
+                   , crypton >= 0.24
   Exposed-modules:   Data.X509
                      Data.X509.EC
   Other-modules:     Data.X509.Internal
@@ -55,10 +55,10 @@ Test-Suite test-x509
                    , hourglass
                    , asn1-types
                    , x509
-                   , cryptonite
+                   , crypton
   ghc-options:       -Wall -fno-warn-orphans -fno-warn-missing-signatures
 
 source-repository head
   type:     git
-  location: git://github.com/vincenthz/hs-certificate
+  location: https://github.com/kazu-yamamoto/crypton-certificate
   subdir:   x509


### PR DESCRIPTION
data-default 0.8 deprecates data-default-class by moving the `Default`
class from `Data.Default.Class` to `Data.Default`.

See: https://github.com/commercialhaskell/stackage/issues/7545